### PR TITLE
Handle possible exceptions thrown while starting the HttpServer

### DIFF
--- a/Agent/PlexExternalPlayerAgent/Program.cs
+++ b/Agent/PlexExternalPlayerAgent/Program.cs
@@ -25,7 +25,16 @@ namespace PlexExternalPlayerAgent
 
             using (var httpServer = new HttpServer(new HttpRequestProvider()))
             {
-                httpServer.Use(new TcpListenerAdapter(new TcpListener(IPAddress.Loopback, 7251)));
+                try
+                {
+                    httpServer.Use(new TcpListenerAdapter(new TcpListener(IPAddress.Loopback, 7251)));
+                }
+                catch (Exception)
+                {
+                    MessageBox.Show($"Could not initilize server (Is another agent already runnning?). Cannot continue, closing agent.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    Environment.Exit(1);
+                }
+
                 httpServer.Use((context, next) =>
                 {
                     Console.WriteLine("Got Request!");


### PR DESCRIPTION
It is possible for the server to fail starting in the case of a port conflict. This is most commonly a conflict with running another instance of the agent, which is a non-issue as the second instance will just quit. There is always a possibility of another program conflicting, however, so maybe it's best to notify the user before force-quitting?
