### PR TITLE
fix overlay icon on cover page

### DIFF
--- a/PlexExternalPlayer.js
+++ b/PlexExternalPlayer.js
@@ -265,7 +265,7 @@ var bindClicks = function() {
     jQuery(".plex-icon-more-560").each(function(i, e) {
         e = jQuery(e);
         var poster = e.parent().parent();
-        if(poster.length === 1 && poster[0].className.startsWith('MetadataPosterCardOverlay'))
+        if(poster.length === 1 && poster[0].className.trim().startsWith('MetadataPosterCardOverlay'))
         {
             var existingButton = poster.find('.plexextplayerico');
             if(existingButton.length === 0)


### PR DESCRIPTION
with plex web 3.14.1, the icon was not showing over the cover.
This fixes it (remove extra space before class name)